### PR TITLE
update: link EDD

### DIFF
--- a/data/courses.yml
+++ b/data/courses.yml
@@ -26,7 +26,7 @@
   codes:
     - IIC2133
   links:
-    telegram: https://t.me/joinchat/25_MJQRMPgIxM2Yx
+    telegram: https://t.me/+AIRknu2gAXRmMGIx
 - name: Ingeniería de Software
   codes:
     - IIC2143


### PR DESCRIPTION
Cambio al link nuevo de telegram de EDD, sin expiración