### PR TITLE
ui: courses and groups pages

### DIFF
--- a/data/courses.yml
+++ b/data/courses.yml
@@ -12,7 +12,7 @@
 - name: Visualización de Información
   abbr: Infovis
   codes:
-    - IC2026
+    - IIC2026
   links:
     telegram: https://t.me/joinchat/LKlvHpQ7LkY4NzBh
 - name: Diseño Detallado de Software
@@ -60,7 +60,7 @@
     - IIC2223
   links:
     telegram: https://t.me/joinchat/CogUgBTfxRlZRxWOwze7Sw
-- name: Grupo de Diseño y Análisis de Algoritmos
+- name: Diseño y Análisis de Algoritmos
   codes:
     - IIC2283
   links:

--- a/src/components/ArrowLink.svelte
+++ b/src/components/ArrowLink.svelte
@@ -1,32 +1,32 @@
 <script lang="ts">
-  import { action } from "nanostores";
+	import { action } from "nanostores";
 
-  import { classNames } from "~/lib/utils";
+	import { classNames } from "~/lib/utils";
 
-  interface $$Props {
-    class?: string;
-    href?: string;
-    action: string;
-  }
-  const { href, class: klass, action } = $$props as $$Props;
+	interface $$Props {
+		class?: string;
+		href?: string;
+		action: string;
+	}
+	const { href, class: klass, action } = $$props as $$Props;
 </script>
 
 <a class={classNames("flex items-center gap-1 text-right leading-none", klass)} {href}>
-  <span class="hover:underline">{action}</span> 
-  <span class="arrow flex-shrink-0">&rarr;</span>
+	<span class="hover:underline">{action}</span>
+	<span class="arrow flex-shrink-0">&rarr;</span>
 </a>
 
 <style lang="scss">
-  .arrow {
-    transition: transform 0.2s ease-in-out;
-    text-decoration: none;
-  }
+	.arrow {
+		transition: transform 0.2s ease-in-out;
+		text-decoration: none;
+	}
 
-  a:hover .arrow {
-    transform: translateX(calc(-1 * theme("spacing.1")));
-  }
+	a:hover .arrow {
+		transform: translateX(calc(-1 * theme("spacing.1")));
+	}
 
-  a:active .arrow {
-    transform: translateX(theme("spacing.1"));
-  }
+	a:active .arrow {
+		transform: translateX(theme("spacing.1"));
+	}
 </style>

--- a/src/components/ArrowLink.svelte
+++ b/src/components/ArrowLink.svelte
@@ -11,23 +11,22 @@
   const { href, class: klass, action } = $$props as $$Props;
 </script>
 
-<a class={classNames("flex items-center gap-1 px-1 text-right leading-none hover:underline", klass)} {href}>
-  {action}
-  <svg class="flex-shrink-0" width="14" height="14" viewBox="0 0 14 14" fill="none" xmlns="http://www.w3.org/2000/svg">
-    <path d="M2.5 7H12M12 7L7 2M12 7L7 12" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" />
-  </svg>
+<a class={classNames("flex items-center gap-1 text-right leading-none", klass)} {href}>
+  <span class="hover:underline">{action}</span> 
+  <span class="arrow flex-shrink-0">&rarr;</span>
 </a>
 
 <style lang="scss">
-  svg {
+  .arrow {
     transition: transform 0.2s ease-in-out;
+    text-decoration: none;
   }
 
-  a:hover svg {
+  a:hover .arrow {
     transform: translateX(calc(-1 * theme("spacing.1")));
   }
 
-  a:active svg {
+  a:active .arrow {
     transform: translateX(theme("spacing.1"));
   }
 </style>

--- a/src/components/ArrowLink.svelte
+++ b/src/components/ArrowLink.svelte
@@ -1,32 +1,32 @@
 <script lang="ts">
-	import { action } from "nanostores";
+  import { action } from "nanostores";
 
-	import { classNames } from "~/lib/utils";
+  import { classNames } from "~/lib/utils";
 
-	interface $$Props {
-		class?: string;
-		href?: string;
-		action: string;
-	}
-	const { href, class: klass, action } = $$props as $$Props;
+  interface $$Props {
+    class?: string;
+    href?: string;
+    action: string;
+  }
+  const { href, class: klass, action } = $$props as $$Props;
 </script>
 
 <a class={classNames("flex items-center gap-1 text-right leading-none", klass)} {href}>
-	<span class="hover:underline">{action}</span>
-	<span class="arrow flex-shrink-0">&rarr;</span>
+  <span class="hover:underline">{action}</span> 
+  <span class="arrow flex-shrink-0">&rarr;</span>
 </a>
 
 <style lang="scss">
-	.arrow {
-		transition: transform 0.2s ease-in-out;
-		text-decoration: none;
-	}
+  .arrow {
+    transition: transform 0.2s ease-in-out;
+    text-decoration: none;
+  }
 
-	a:hover .arrow {
-		transform: translateX(calc(-1 * theme("spacing.1")));
-	}
+  a:hover .arrow {
+    transform: translateX(calc(-1 * theme("spacing.1")));
+  }
 
-	a:active .arrow {
-		transform: translateX(theme("spacing.1"));
-	}
+  a:active .arrow {
+    transform: translateX(theme("spacing.1"));
+  }
 </style>

--- a/src/pages/cursos.astro
+++ b/src/pages/cursos.astro
@@ -4,42 +4,44 @@ import * as yaml from "js-yaml";
 import BaseLayout from "~/layouts/Base.astro";
 import ArrowLink from "~/components/ArrowLink.svelte";
 import telegramIcon from "$/icons/telegram.svg";
-import bannerImage from "$/og/specific/cursos.png"
+import bannerImage from "$/og/specific/cursos.png";
 
 type Course = {
-    codes: string[];
-    abbr?: string;
-    name: string;
-    links: { [name: string]: string };
+	codes: string[];
+	abbr?: string;
+	name: string;
+	links: { [name: string]: string };
 };
 
 const courses = yaml.load(coursesRaw) as Course[];
 ---
 
 <BaseLayout {bannerImage}>
-    <div class="px-4 py-8">
-        <h2 class="font-title text-xl">Cursos</h2>
-        Listado de cursos importantes para la carrera
-    </div>
-    <div class="bg-stone-200 shadow-inner">
-        <ul class="course-grid p-4 grid grip-tem max-w-4xl mx-auto">
-            {courses.map(({ codes, name, links }) => (
-            <li class="bg-white rounded py-4 px-2 flex">
-                <div class="flex flex-col justify-around">
-                    <p class="py-1">{name}</p>
-                    {(codes && codes.length > 0) ? <p class="py-1">Sigla: {codes.join(", ")}</p> : null}
-                    <ArrowLink action="Telegram" href={links.telegram} class="text-blue-500 py-1"/>
-                </div>
-            </li>
-            ))}
-        </ul>
-    </div>
+	<div class="px-4 py-8">
+		<h2 class="font-title text-xl">Cursos</h2>
+		Listado de cursos importantes para la carrera
+	</div>
+	<div class="bg-stone-200 shadow-inner">
+		<ul class="course-grid p-4 grid grip-tem max-w-4xl mx-auto">
+			{
+				courses.map(({ codes, name, links }) => (
+					<li class="flex rounded bg-white py-4 px-2">
+						<div class="flex flex-col justify-around">
+							<p class="py-1">{name}</p>
+							{codes && codes.length > 0 ? <p class="py-1">Sigla: {codes.join(", ")}</p> : null}
+							<ArrowLink action="Telegram" href={links.telegram} class="py-1 text-blue-500" />
+						</div>
+					</li>
+				))
+			}
+		</ul>
+	</div>
 </BaseLayout>
 
 <style lang="scss">
-    .course-grid {
-        gap: 15px;
-        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-        grid-auto-rows: 1fr;
-    }
+	.course-grid {
+		gap: 15px;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		grid-auto-rows: 1fr;
+	}
 </style>

--- a/src/pages/cursos.astro
+++ b/src/pages/cursos.astro
@@ -26,9 +26,9 @@ const courses = yaml.load(coursesRaw) as Course[];
             {courses.map(({ codes, name, links }) => (
             <li class="bg-white rounded py-4 px-2 flex">
                 <div class="flex flex-col justify-around">
-                    <span>{name}</span>
-                    {(codes && codes.length > 0) ? <span>({codes.join(", ")})</span> : null}
-                    <ArrowLink action="Telegram" href={links.telegram} class="text-blue-500"/>
+                    <p class="py-1">{name}</p>
+                    {(codes && codes.length > 0) ? <p class="py-1">Sigla: {codes.join(", ")}</p> : null}
+                    <ArrowLink action="Telegram" href={links.telegram} class="text-blue-500 py-1"/>
                 </div>
             </li>
             ))}

--- a/src/pages/cursos.astro
+++ b/src/pages/cursos.astro
@@ -4,44 +4,42 @@ import * as yaml from "js-yaml";
 import BaseLayout from "~/layouts/Base.astro";
 import ArrowLink from "~/components/ArrowLink.svelte";
 import telegramIcon from "$/icons/telegram.svg";
-import bannerImage from "$/og/specific/cursos.png";
+import bannerImage from "$/og/specific/cursos.png"
 
 type Course = {
-	codes: string[];
-	abbr?: string;
-	name: string;
-	links: { [name: string]: string };
+    codes: string[];
+    abbr?: string;
+    name: string;
+    links: { [name: string]: string };
 };
 
 const courses = yaml.load(coursesRaw) as Course[];
 ---
 
 <BaseLayout {bannerImage}>
-	<div class="px-4 py-8">
-		<h2 class="font-title text-xl">Cursos</h2>
-		Listado de cursos importantes para la carrera
-	</div>
-	<div class="bg-stone-200 shadow-inner">
-		<ul class="course-grid p-4 grid grip-tem max-w-4xl mx-auto">
-			{
-				courses.map(({ codes, name, links }) => (
-					<li class="flex rounded bg-white py-4 px-2">
-						<div class="flex flex-col justify-around">
-							<p class="py-1">{name}</p>
-							{codes && codes.length > 0 ? <p class="py-1">Sigla: {codes.join(", ")}</p> : null}
-							<ArrowLink action="Telegram" href={links.telegram} class="py-1 text-blue-500" />
-						</div>
-					</li>
-				))
-			}
-		</ul>
-	</div>
+    <div class="px-4 py-8">
+        <h2 class="font-title text-xl">Cursos</h2>
+        Listado de cursos importantes para la carrera
+    </div>
+    <div class="bg-stone-200 shadow-inner">
+        <ul class="course-grid p-4 grid grip-tem max-w-4xl mx-auto">
+            {courses.map(({ codes, name, links }) => (
+            <li class="bg-white rounded py-4 px-2 flex hover:shadow-lg">
+                <div class="flex flex-col justify-around">
+                    <p class="py-1"><b>{name}</b></p>
+                    {(codes && codes.length > 0) ? <p class="py-1">{codes.join(", ")}</p> : null}
+                    <ArrowLink action="Telegram" href={links.telegram} class="text-blue-500 py-1"/>
+                </div>
+            </li>
+            ))}
+        </ul>
+    </div>
 </BaseLayout>
 
 <style lang="scss">
-	.course-grid {
-		gap: 15px;
-		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-		grid-auto-rows: 1fr;
-	}
+    .course-grid {
+        gap: 15px;
+        grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+        grid-auto-rows: 1fr;
+    }
 </style>

--- a/src/pages/cursos.astro
+++ b/src/pages/cursos.astro
@@ -1,7 +1,9 @@
 ---
 import coursesRaw from "/data/courses.yml?raw";
 import * as yaml from "js-yaml";
-import BaseLayout from "~/layouts/Base.astro"
+import BaseLayout from "~/layouts/Base.astro";
+import ArrowLink from "~/components/ArrowLink.svelte";
+import telegramIcon from "$/icons/telegram.svg";
 import bannerImage from "$/og/specific/cursos.png"
 
 type Course = {
@@ -21,22 +23,13 @@ const courses = yaml.load(coursesRaw) as Course[];
     </div>
     <div class="bg-stone-200 shadow-inner">
         <ul class="course-grid p-4 grid grip-tem max-w-4xl mx-auto">
-            {courses.map(({ codes, name, abbr, links }) => (
-            <li class="bg-white rounded py-4 px-2">
-                <div>
-                    <>{abbr ? ( <><span>{abbr}</span> - </> ) : null}</>
+            {courses.map(({ codes, name, links }) => (
+            <li class="bg-white rounded py-4 px-2 flex">
+                <div class="flex flex-col justify-around">
                     <span>{name}</span>
-                    <>{(codes && codes.length > 0) ? <span>({codes.join(", ")})</span> : null}</>
+                    {(codes && codes.length > 0) ? <span>({codes.join(", ")})</span> : null}
+                    <ArrowLink action="Telegram" href={links.telegram} class="text-blue-500"/>
                 </div>
-                <ul>
-                    {Object.entries(links).map(([name, href]) => (
-                    <li>
-                        <a {href} class="text-blue-500 hover:underline">
-                            {name}
-                        </a>
-                    </li>
-                    ))}
-                </ul>
             </li>
             ))}
         </ul>

--- a/src/pages/grupos.astro
+++ b/src/pages/grupos.astro
@@ -3,44 +3,45 @@ import groupsRaw from "/data/groups.yml?raw";
 import * as yaml from "js-yaml";
 import BaseLayout from "~/layouts/Base.astro";
 import ArrowLink from "~/components/ArrowLink.svelte";
-import bannerImage from "$/og/specific/cursos.png"
+import bannerImage from "$/og/specific/cursos.png";
 
 type Group = {
-  name: string,
-  description: string,
-  telegram: string,
+	name: string;
+	description: string;
+	telegram: string;
 };
 
 const groups = yaml.load(groupsRaw) as Group[];
 ---
 
 <BaseLayout {bannerImage}>
-  <div class="px-4 py-8">
-    <h2 class="font-title text-xl">Grupos</h2>
-    Listado de grupos relevantes del DCC.
-  </div>
-  <div class="bg-stone-200 shadow-inner">
-      <ul class="group-grid p-4 grid grip-tem max-w-4xl mx-auto">
-          {groups.map(({ name, description, telegram }) => (
-            <li class="bg-white rounded py-4 px-2 flex flex-col justify-around">
-              <div class="py-2">
-                  <span><b>{name}</b></span>
-              </div>
-              <div class="py-2">
-                {description}
-              </div>
-                <ArrowLink action="Telegram" href={telegram}
-                 class="text-blue-500 py-2"/>
-            </li>
-          ))}
-      </ul>
-  </div>
+	<div class="px-4 py-8">
+		<h2 class="font-title text-xl">Grupos</h2>
+		Listado de grupos relevantes del DCC.
+	</div>
+	<div class="bg-stone-200 shadow-inner">
+		<ul class="group-grid p-4 grid grip-tem max-w-4xl mx-auto">
+			{
+				groups.map(({ name, description, telegram }) => (
+					<li class="flex flex-col justify-around rounded bg-white py-4 px-2">
+						<div class="py-2">
+							<span>
+								<b>{name}</b>
+							</span>
+						</div>
+						<div class="py-2">{description}</div>
+						<ArrowLink action="Telegram" href={telegram} class="py-2 text-blue-500" />
+					</li>
+				))
+			}
+		</ul>
+	</div>
 </BaseLayout>
 
 <style lang="scss">
-  .group-grid {
-      gap: 15px;
-      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-      grid-auto-rows: 1fr;
-  }
+	.group-grid {
+		gap: 15px;
+		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+		grid-auto-rows: 1fr;
+	}
 </style>

--- a/src/pages/grupos.astro
+++ b/src/pages/grupos.astro
@@ -2,6 +2,7 @@
 import groupsRaw from "/data/groups.yml?raw";
 import * as yaml from "js-yaml";
 import BaseLayout from "~/layouts/Base.astro";
+import ArrowLink from "~/components/ArrowLink.svelte";
 import bannerImage from "$/og/specific/cursos.png"
 
 type Group = {
@@ -21,18 +22,15 @@ const groups = yaml.load(groupsRaw) as Group[];
   <div class="bg-stone-200 shadow-inner">
       <ul class="group-grid p-4 grid grip-tem max-w-4xl mx-auto">
           {groups.map(({ name, description, telegram }) => (
-            <li class="bg-white rounded py-4 px-2">
-              <div>
+            <li class="bg-white rounded py-4 px-2 flex flex-col justify-around">
+              <div class="py-2">
                   <span><b>{name}</b></span>
               </div>
-              <div>
+              <div class="py-2">
                 {description}
               </div>
-              <div>
-                <a href={telegram} class="text-blue-500 hover:underline">
-                  Telegram
-                </a>
-              </div>
+                <ArrowLink action="Telegram" href={telegram}
+                 class="text-blue-500 py-2"/>
             </li>
           ))}
       </ul>

--- a/src/pages/grupos.astro
+++ b/src/pages/grupos.astro
@@ -3,45 +3,44 @@ import groupsRaw from "/data/groups.yml?raw";
 import * as yaml from "js-yaml";
 import BaseLayout from "~/layouts/Base.astro";
 import ArrowLink from "~/components/ArrowLink.svelte";
-import bannerImage from "$/og/specific/cursos.png";
+import bannerImage from "$/og/specific/cursos.png"
 
 type Group = {
-	name: string;
-	description: string;
-	telegram: string;
+  name: string,
+  description: string,
+  telegram: string,
 };
 
 const groups = yaml.load(groupsRaw) as Group[];
 ---
 
 <BaseLayout {bannerImage}>
-	<div class="px-4 py-8">
-		<h2 class="font-title text-xl">Grupos</h2>
-		Listado de grupos relevantes del DCC.
-	</div>
-	<div class="bg-stone-200 shadow-inner">
-		<ul class="group-grid p-4 grid grip-tem max-w-4xl mx-auto">
-			{
-				groups.map(({ name, description, telegram }) => (
-					<li class="flex flex-col justify-around rounded bg-white py-4 px-2">
-						<div class="py-2">
-							<span>
-								<b>{name}</b>
-							</span>
-						</div>
-						<div class="py-2">{description}</div>
-						<ArrowLink action="Telegram" href={telegram} class="py-2 text-blue-500" />
-					</li>
-				))
-			}
-		</ul>
-	</div>
+  <div class="px-4 py-8">
+    <h2 class="font-title text-xl">Grupos</h2>
+    Listado de grupos relevantes del DCC.
+  </div>
+  <div class="bg-stone-200 shadow-inner">
+      <ul class="group-grid p-4 grid grip-tem max-w-4xl mx-auto">
+          {groups.map(({ name, description, telegram }) => (
+            <li class="bg-white rounded py-4 px-2 flex flex-col justify-around hover:shadow-lg">
+              <div class="py-2">
+                  <b>{name}</b>
+              </div>
+              <div class="py-2">
+                {description}
+              </div>
+                <ArrowLink action="Telegram" href={telegram}
+                 class="text-blue-500 py-2"/>
+            </li>
+          ))}
+      </ul>
+  </div>
 </BaseLayout>
 
 <style lang="scss">
-	.group-grid {
-		gap: 15px;
-		grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
-		grid-auto-rows: 1fr;
-	}
+  .group-grid {
+      gap: 15px;
+      grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+      grid-auto-rows: 1fr;
+  }
 </style>


### PR DESCRIPTION
Esta PR busca mejorar un poco la interfaz de usuario en las vistas de `cursos` y `grupos`.
- Los links en estas vistas fueron reemplazados por el componente `ArrowLink.svelte`
- Se arreglo un typo en `data/courses.yaml`

Probablemente en un futuro sea una buena idea crear un componente `Card` que se pueda utilizar en ambas vistas. 😄 