### PR TITLE
Docs/update about us

### DIFF
--- a/src/components/LandingCard.astro
+++ b/src/components/LandingCard.astro
@@ -9,7 +9,7 @@ export interface Props {
 	href: string;
 }
 
-const defaultCallToAction = "ir al listado";
+const defaultCallToAction = "Ir al listado";
 
 const { title, callToAction = defaultCallToAction, href = "#", ...props } = Astro.props as Props;
 ---

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -34,10 +34,10 @@ import { getNextEventsCalendar } from "~/lib/calendar";
 	<!-- 3 Targetas -->
 	<div class="-mt-4 flex flex-col items-center justify-center gap-4 px-2 pb-4 md:flex-row">
 		<LandingCard title="Cursos DCC" class="bg-light-morado" href="/cursos">
-			Listado de cursos del departamento, con sus respectivos links a Telegram
+			Listado de cursos del departamento con sus respectivos links a Telegram
 		</LandingCard>
 		<LandingCard title="Representantes" class="bg-light-purpura" href="/representantes">
-			Equipo del capitulo, delegados, y otros representantes junto a su información de contacto
+			Equipo del capítulo, delegados y otros representantes junto a su información de contacto
 		</LandingCard>
 		<LandingCard title="Grupos e Iniciativas" class="bg-light-celeste" href="/grupos">
 			Diferentes clubs, grupos e iniciativas relacionadas al departamento
@@ -91,7 +91,7 @@ import { getNextEventsCalendar } from "~/lib/calendar";
 		<div class="flex flex-wrap items-center justify-center gap-4">
 			<LinkCard href="/ayudantias" src={ayudanteImg} name="Ayudantías" />
 			<LinkCard href="https://dcc.ing.puc.cl" src={dccImg} name="DCC" />
-			<LinkCard href="https://cienciadelacomputacion.uc.cl" src={LicDCImg} name="Licenciatura de Computación" />
+			<LinkCard href="https://cienciadelacomputacion.uc.cl" src={LicDCImg} name="Ciencia de la Computación" />
 			<LinkCard href="/labs" src={dccImg} name="Grupos de Investigación" />
 		</div>
 	</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -91,7 +91,7 @@ import { getNextEventsCalendar } from "~/lib/calendar";
 		<div class="flex flex-wrap items-center justify-center gap-4">
 			<LinkCard href="/ayudantias" src={ayudanteImg} name="Ayudantías" />
 			<LinkCard href="https://dcc.ing.puc.cl" src={dccImg} name="DCC" />
-			<LinkCard href="https://cienciadelacomputacion.uc.cl" src={LicDCImg} name="Ciencia de la Computación" />
+			<LinkCard href="https://cienciadelacomputacion.uc.cl" src={LicDCImg} name="LICC" />
 			<LinkCard href="/labs" src={dccImg} name="Grupos de Investigación" />
 		</div>
 	</div>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -6,7 +6,6 @@ import ArrowLink from "~/components/ArrowLink.svelte";
 import LinkCard from "~/components/LinkCard.astro";
 import LandingEvents from "~/components/LandingEvents.svelte";
 
-import telegramIcon from "~/assets/icons/telegram.svg";
 import linkedinIcon from "~/assets/icons/linkedin.svg";
 import facebookIcon from "~/assets/icons/facebook.svg";
 import instagramIcon from "~/assets/icons/instagram.svg";
@@ -66,9 +65,6 @@ import { getNextEventsCalendar } from "~/lib/calendar";
 			<div class="mt-4 flex flex-col items-center justify-center gap-4 xs:flex-row">
 				<!-- Redes sociales -->
 				<div class="flex gap-1">
-					<a href="https://t.me/expldccasd" class="p-1">
-						<img class="h-6 w-6" src={telegramIcon.src} alt="Telegr am icon" />
-					</a>
 					<a href="https://www.linkedin.com/company/dcc-ccc/" class="p-1">
 						<img class="h-6 w-6" src={linkedinIcon.src} alt="LinkedIn icon" />
 					</a>

--- a/src/pages/representantes/index.astro
+++ b/src/pages/representantes/index.astro
@@ -35,8 +35,8 @@ import Delegados from "./Delegados.svelte";
 		<div id="del-card" class="rounded bg-stone-100 px-4 py-8">
 			<h2 class="mb-2 font-title text-2xl">Delegados</h2>
 			<p>
-				Los delegados son los que representan a los estudiantes en el Consejo Academico del Centro de Alumnos de
-				ingeniería (CAi).
+				Los delegados son quienes representan a los estudiantes en el Consejo Académico del Centro de Alumnos de
+				Ingeniería (CAi).
 			</p>
 			<Delegados client:idle />
 		</div>

--- a/src/pages/representantes/index.astro
+++ b/src/pages/representantes/index.astro
@@ -28,6 +28,9 @@ import Delegados from "./Delegados.svelte";
 				<p>
 					Organizamos eventos y proyectos principalmente dirigidos a la comunidad del DCC, tanto de Major y Minor como de la Licenciatura en Ingeniería en Ciencia de la Computación (LICC), llegando a cientos de estudiantes de Ingeniería UC.
 				</p>
+				<p>
+					Puedes contactarnos a través de <a href="mailto:capitulo_dcc@uc.cl">capitulo_dcc@uc.cl</a>.
+				</p>
 			</div>
 			<h2 class="mb-2 mt-6 font-title text-xl">Directiva</h2>
 			<CCC client:idle />

--- a/src/pages/representantes/index.astro
+++ b/src/pages/representantes/index.astro
@@ -26,17 +26,7 @@ import Delegados from "./Delegados.svelte";
 					Católica de Chile.
 				</p>
 				<p>
-					Organizamos eventos y proyectos principalmente dirigidos a alumnos que estudien en el DCC, tanto por Major,
-					Minor, o por la licenciatura de computación, llegando a cientos de estudiantes de Ingeniería UC.
-				</p>
-				<!-- <p>
-					Las actividades que organizamos abarcan diferentes áreas, como comunitarias, sobre investigación y sobre el
-					mercado labora. Para esto, colaboramos con diferentes empresas, grupos de investigación y otros grupos de
-					estudiantes.
-				</p> -->
-				<p>
-					Puedes unirte al capítulo en <a href="https://forms.gle/oZMNREocWonkszAr8">este formulario</a>, o puedes
-					contactarnos con <a href="mailto:capitulo_dcc@uc.cl">capitulo_dcc@uc.cl</a>.
+					Organizamos eventos y proyectos principalmente dirigidos a la comunidad del DCC, tanto de Major y Minor como de la Licenciatura en Ingeniería en Ciencia de la Computación (LICC), llegando a cientos de estudiantes de Ingeniería UC.
 				</p>
 			</div>
 			<h2 class="mb-2 mt-6 font-title text-xl">Directiva</h2>


### PR DESCRIPTION
# Cambios realizados

-  Se removió un link no utilizado hacia Telegram en la landing page.
- Se ha removido un formulario de inscripción al CCC 25 deprecado.
- Se corrigió la ortografía y gramática de algunas secciones del about us (tanto en la landing page, como en la página de representantes).